### PR TITLE
🐛低速モード=0のときスレッドをDBに登録する前に処理が終了する

### DIFF
--- a/cogs/thread_keeper.py
+++ b/cogs/thread_keeper.py
@@ -196,6 +196,12 @@ class Hofumi(commands.Cog, name='Thread管理用cog'):
         # OPとbotを呼ぶ処理
         await self.call_of_thread(thread)
 
+
+        # DBの設定を確認、管理対象としてDBに入れる
+        if await self.guild_setting_mng.is_full_maintainance(thread.guild.id):
+            archive_time = self.return_estimated_archive_time(thread)
+            await self.channel_data_manager.resister_channel(channel_id=thread.id, guild_id=thread.guild.id, archive_time=archive_time)
+        
         # 低速モードを引き継ぎ
         if thread.parent is not None:
             try:
@@ -208,10 +214,6 @@ class Hofumi(commands.Cog, name='Thread管理用cog'):
                 print("権限不足")
                 print(thread)
 
-        # DBの設定を確認、管理対象としてDBに入れる
-        if await self.guild_setting_mng.is_full_maintainance(thread.guild.id):
-            archive_time = self.return_estimated_archive_time(thread)
-            await self.channel_data_manager.resister_channel(channel_id=thread.id, guild_id=thread.guild.id, archive_time=archive_time)
 
     @commands.Cog.listener()
     async def on_thread_update(self, before: discord.Thread, after: discord.Thread):


### PR DESCRIPTION
ここの部分で、
https://github.com/being24/hohumi/blob/a222a108a4b96ac45a83501fec110218a599887f/cogs/thread_keeper.py#L200-L214
低速モード=0のとき、if内のreturnで処理が終わってしまうため、管理対象としてDBに登録されません。

その為、先に管理対象を登録する方をもってきてます。
if内で、tryまで抜けてそのまま処理を続けるものが思いつかなかったためこうしてあります。
